### PR TITLE
Remove deprecated picom options

### DIFF
--- a/config
+++ b/config
@@ -164,21 +164,12 @@ detect-rounded-corners = true;
 # For example without this enabled my xfce4-notifyd is 100% opacity no matter what.
 detect-client-opacity = true;
 
-# Specify refresh rate of the screen.
-# If not specified or 0, picom will try detecting this with X RandR extension.
-refresh-rate = 0;
-
 # Set VSync.
 vsync = true;
 
 # Enable DBE painting mode, intended to use with VSync to (hopefully) eliminate tearing.
 # Reported to have no effect, though.
 dbe = false;
-
-# Limit picom to repaint at most once every 1 / refresh_rate second to boost performance.
-# This should not be used with --vsync drm/opengl/opengl-oml as they essentially does --sw-opti's job already,
-# unless you wish to specify a lower refresh rate than the actual value.
-sw-opti = false;
 
 # Unredirect all windows if a full-screen opaque window is detected, to maximize performance for full-screen windows, like games.
 # Known to cause flickering when redirecting/unredirecting windows.


### PR DESCRIPTION
Cleanup deprecated picom options.

With Regolith 2.2 I've been getting these in my logs:

```
[ 12/23/2022 08:17:56.919 parse_config_libconfig WARN ] The refresh-rate option has been deprecated. Please remove it from your configuration file. If you encounter any problems without this feature, please feel free to open a bug report
[ 12/23/2022 08:17:56.919 parse_config_libconfig WARN ] The sw-opti option has been deprecated. Please remove it from your configuration file. If you encounter any problems without this feature, please feel free to open a bug report
```

My picom version is showing as:

```
$ picom --version
vgit-d4e24
```

I don't know if these options are also deprecated in compton, or just picom.

Same change as https://github.com/regolith-linux/regolith-look-extra/pull/11